### PR TITLE
fix libro de iva

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -292,7 +292,7 @@ class L10nEsVatBook(models.Model):
 
     def _get_account_move_lines(self, taxes):
         return self.env['account.move.line'].search(
-            self._account_move_line_domain(taxes))
+            self._account_move_line_domain(taxes)).sorted(lambda ml: ml.account_id.code)
 
     @ormcache('self.id')
     def get_pos_partner_ids(self):


### PR DESCRIPTION
en algunos clientes, algunos asientos se generan desordenados (no sé por qué), y al calcularse el libro de iva, si hay impuestos especiales como recargo de equivalencia, y el asiento no está ordenado, no lo calcula bien, ordenamos por código de cuenta ya que es el orden lógico de los asientos