### PR TITLE
Task#99786

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1145,18 +1145,35 @@ class AccountInvoice(models.Model):
                         unicode(res_line['DescripcionErrorRegistro'])[:60])
                 inv_vals['sii_send_error'] = send_error
                 invoice.write(inv_vals)
+                self.env.cr.commit()
             except Exception as fault:
-                new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
-                env = api.Environment(new_cr, self.env.uid, self.env.context)
-                invoice = env['account.invoice'].browse(self.id)
-                inv_vals.update({
-                    'sii_send_failed': True,
-                    'sii_send_error': ustr(fault),
-                    'sii_return': ustr(fault),
-                })
-                invoice.write(inv_vals)
-                new_cr.commit()
-                new_cr.close()
+                # new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
+                # env = api.Environment(new_cr, self.env.uid, self.env.context)
+                # invoice = env['account.invoice'].browse(self.id)
+                # inv_vals.update({
+                #     'sii_send_failed': True,
+                #     'sii_send_error': ustr(fault),
+                #     'sii_return': ustr(fault),
+                # })
+                # invoice.write(inv_vals)
+                # new_cr.commit()
+                # new_cr.close()
+                # raise
+                self.env.cr.rollback()
+                invoice = self.env['account.invoice'].browse(self.id)
+                # Si da un error de update recurrente, lo filtramos para que no lo
+                # escriba,ya que es un error de odoo,no del sii
+                if hasattr(fault, 'message') and fault.message.strip() == \
+                        "no se pudo serializar el acceso debido a un update concurrente":
+                    pass
+                else:
+                    inv_vals.update({
+                        'sii_send_failed': True,
+                        'sii_send_error': fault,
+                        'sii_return': fault,
+                    })
+                    invoice.write(inv_vals)
+                    self.env.cr.commit()
                 raise
 
     @api.multi


### PR DESCRIPTION
en el módulo del sii de la oca, cuando envían varias facturas a la vez, si una de ellas la devuelven con errores, el resto de facturas se quedan sin el estado del sii guardado, y aparecen como no enviadas, pero en realidad sí lo están. En nuestro módulo del sii de los descuentos globales (nubea_discount_invoice_aeat_sii) ya hicimos el arreglo para que esto no pasara. Hacemos el mismo arreglo para los clientes como los rentacar que no usan los descuentos globales pero sí usan el sii.
