### PR TITLE
arreglados errores al enviar algunas sesiones al sii con casos que no se habían contemplado

### DIFF
--- a/l10n_es_aeat_sii_pos_summary/i18n/es.po
+++ b/l10n_es_aeat_sii_pos_summary/i18n/es.po
@@ -19,7 +19,13 @@ msgstr ""
 #: code:addons/l10n_es_aeat_sii_pos_summary/models/pos_session.py:0
 #, python-format
 msgid "A simplified invoice sequence must be cofigured"
-msgstr ""
+msgstr "Debe configurarse una secuencia de factura simplificada"
+
+#. module: l10n_es_aeat_sii_pos_summary
+#: code:addons/l10n_es_aeat_sii_pos_summary/models/pos_session.py:0
+#, python-format
+msgid "Cannot send any summary to SII. All orders have been invoiced"
+msgstr "No se puede enviar resumen al SII. Todo los pedidos se han facturado"
 
 #. module: l10n_es_aeat_sii_pos_summary
 #: model:ir.model.fields.selection,name:l10n_es_aeat_sii_pos_summary.selection__pos_session__sii_state__sent_w_errors

--- a/l10n_es_aeat_sii_pos_summary/i18n/l10n_es_aeat_sii_pos_summary.pot
+++ b/l10n_es_aeat_sii_pos_summary/i18n/l10n_es_aeat_sii_pos_summary.pot
@@ -22,6 +22,12 @@ msgid "A simplified invoice sequence must be cofigured"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_pos_summary
+#: code:addons/l10n_es_aeat_sii_pos_summary/models/pos_session.py:0
+#, python-format
+msgid "Cannot send any summary to SII. All orders have been invoiced"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_pos_summary
 #: model:ir.model.fields.selection,name:l10n_es_aeat_sii_pos_summary.selection__pos_session__sii_state__sent_w_errors
 msgid "Accepted with errors"
 msgstr ""

--- a/l10n_es_aeat_sii_pos_summary/models/account_move.py
+++ b/l10n_es_aeat_sii_pos_summary/models/account_move.py
@@ -40,4 +40,5 @@ class AccountMove(models.Model):
         tax_dict = super(AccountMove, self)._get_sii_tax_dict(tax_line, tax_lines)
         if self._context.get("from_pos"):
             tax_dict["CuotaRepercutida"] = round(tax_dict.pop("CuotaSoportada"), 2)
+            tax_dict["BaseImponible"] = round(tax_dict.pop("BaseImponible"), 2)
         return tax_dict


### PR DESCRIPTION
- redondeo a 2 decimales de las bases imponibles
- si sólo hay un pedido en la sesión, no se permite enviar resumen porque el número de inicio y fin no puede ser el mismo, en ese caso se enviará como factura simplificada
- si no hay pedidos para el resumen porque se han facturado todos, que avise al usuario, en vez de petar, para que sepan que esa sesión no se envía al sii por ese motivo y la puedan excluir.