### PR TITLE
Task#111715

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1147,7 +1147,8 @@ class AccountInvoice(models.Model):
                 invoice.write(inv_vals)
                 self.env.cr.commit()
             except Exception as fault:
-                if hasattr(fault, 'message') and fault.message.strip() == \
+                if hasattr(fault, 'message') and hasattr(fault.message, 'strip') and \
+                        fault.message.strip() == \
                         "no se pudo serializar el acceso debido a un update concurrente":
                     pass
                 else:


### PR DESCRIPTION
Modificamos el parseo del error para poder ver el mensaje de ProtocolError que está devolviendo en telefurgo, ya que no es un string que devuelva la aeat sino un error de xmlrpclib
