### PR TITLE
Add verifactu hash code

### DIFF
--- a/l10n_es_aeat_verifactu/__manifest__.py
+++ b/l10n_es_aeat_verifactu/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Aures Tic - Jose Zambudio <jose@aurestic.es>
+# Copyright 2024 Aures TIC - Almudena de La Puente <almudena@aurestic.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_verifactu/models/account_journal.py
+++ b/l10n_es_aeat_verifactu/models/account_journal.py
@@ -5,6 +5,12 @@ from odoo.exceptions import ValidationError
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
+    # TODEL?
+    # no vamos autilizar el hash de odoo porque la estructura no nos sirve
+    # para verifactu, por lo que este código no nos terminaría de valer.
+    # De momento lo dejamos hasta saber cómo vamos a controlar
+    # el tema de la factura anterior enviada a verifactu para el cálculo
+    # del hash, y el control de modificaciones en las facturas ya enviadas.
     restrict_mode_hash_table = fields.Boolean(
         compute="_compute_restrict_mode_hash_table",
         store=True,

--- a/l10n_es_aeat_verifactu/models/account_move.py
+++ b/l10n_es_aeat_verifactu/models/account_move.py
@@ -1,4 +1,9 @@
-from odoo import api, models
+# Copyright 2024 Aures TIC - Almudena de La Puente <almudena@aurestic.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import pytz
+
+from odoo import _, api, fields, models
 
 VERIFACTU_VALID_INVOICE_STATES = ["posted"]
 
@@ -6,6 +11,36 @@ VERIFACTU_VALID_INVOICE_STATES = ["posted"]
 class AccountMove(models.Model):
     _name = "account.move"
     _inherit = ["account.move", "verifactu.mixin"]
+
+    verifactu_document_type = fields.Selection(
+        selection=lambda self: self._get_verifactu_docuyment_types(),
+        default="F1",
+    )
+
+    def _get_verifactu_docuyment_types(self):
+        return [
+            ("F1", _("FACTURA (ART. 6, 7.2 Y 7.3 DEL RD 1619/2012)")),
+            (
+                "F2",
+                _(
+                    "FACTURA SIMPLIFICADA Y FACTURAS SIN IDENTIFICACIÓN DEL DESTINATARIO ART. 6.1.D) RD 1619/2012"
+                ),
+            ),
+            (
+                "R1",
+                _("FACTURA RECTIFICATIVA (Art 80.1 y 80.2 y error fundado en derecho)"),
+            ),
+            ("R2", _("FACTURA RECTIFICATIVA (Art. 80.3)")),
+            ("R3", _("FACTURA RECTIFICATIVA (Art. 80.4)")),
+            ("R4", _("FACTURA RECTIFICATIVA (Resto)")),
+            ("R5", _("FACTURA RECTIFICATIVA EN FACTURAS SIMPLIFICADAS")),
+            (
+                "F3",
+                _(
+                    "FACTURA EMITIDA EN SUSTITUCIÓN DE FACTURAS SIMPLIFICADAS FACTURADAS Y DECLARADAS"
+                ),
+            ),
+        ]
 
     @api.depends(
         "company_id",
@@ -30,7 +65,7 @@ class AccountMove(models.Model):
         TODO: this method is the same in l10n_es_aeat_sii_oca, so I think that
         it should be directly in l10n_es_aeat
         """
-        return self.invoice_date
+        return self._change_date_format(self.invoice_date)
 
     def _aeat_get_partner(self):
         """
@@ -65,3 +100,61 @@ class AccountMove(models.Model):
         if self.thirdparty_invoice:
             serial_number = self.thirdparty_number[0:60]
         return serial_number
+
+    def _get_verifactu_issuer(self):
+        return self.company_id.partner_id._parse_aeat_vat_info()[2]
+
+    def _get_verifactu_document_type(self):
+        return self.verifactu_document_type or "F1"
+
+    def _get_verifactu_amount_tax(self):
+        return self.amount_tax
+
+    def _get_verifactu_amount_total(self):
+        return self.amount_total
+
+    def _get_verifactu_previous_hash(self):
+        # TODO store it? search it by some kind of sequence?
+        return ""
+
+    def _get_verifactu_registration_date(self):
+        # Date format must be like "2024-01-01T19:20:30+01:00"
+        return pytz.utc.localize(self.create_date).isoformat()
+
+    @api.model
+    def _get_verifactu_hash_string(self):
+        """Gets the verifactu hash string"""
+        if (
+            not self.verifactu_enabled
+            or self.state == "draft"
+            or self.move_type not in ("out_invoice", "out_refund")
+        ):
+            return ""
+        issuerID = self._get_verifactu_issuer()
+        serialNumber = self._get_document_serial_number()
+        expeditionDate = self._get_document_date()
+        documentType = self._get_verifactu_document_type()
+        amountTax = self._get_verifactu_amount_tax()
+        amountTotal = self._get_verifactu_amount_total()
+        previousHash = self._get_verifactu_previous_hash()
+        registrationDate = self._get_verifactu_registration_date()
+        verifactu_hash_string = (
+            "IDEmisorFactura={}&"
+            "NumSerieFactura={}&"
+            "FechaExpedicionFactura={}&"
+            "TipoFactura={}&"
+            "CuotaTotal={}&"
+            "ImporteTotal={}&"
+            "Huella={}&"
+            "FechaHoraHusoGenRegistro={}"
+        ).format(
+            issuerID,
+            serialNumber,
+            expeditionDate,
+            documentType,
+            amountTax,
+            amountTotal,
+            previousHash,
+            registrationDate,
+        )
+        return verifactu_hash_string

--- a/l10n_es_aeat_verifactu/models/account_move.py
+++ b/l10n_es_aeat_verifactu/models/account_move.py
@@ -24,7 +24,8 @@ class AccountMove(models.Model):
             (
                 "F2",
                 _(
-                    "FACTURA SIMPLIFICADA Y FACTURAS SIN IDENTIFICACIÓN DEL DESTINATARIO ART. 6.1.D) RD 1619/2012"
+                    """FACTURA SIMPLIFICADA Y FACTURAS SIN IDENTIFICACIÓN DEL DESTINATARIO
+                    (ART. 6.1.D RD 1619/2012)"""
                 ),
             ),
             (
@@ -38,7 +39,8 @@ class AccountMove(models.Model):
             (
                 "F3",
                 _(
-                    "FACTURA EMITIDA EN SUSTITUCIÓN DE FACTURAS SIMPLIFICADAS FACTURADAS Y DECLARADAS"
+                    """FACTURA EMITIDA EN SUSTITUCIÓN DE FACTURAS SIMPLIFICADAS FACTURADAS
+                    Y DECLARADAS"""
                 ),
             ),
         ]

--- a/l10n_es_aeat_verifactu/models/account_move.py
+++ b/l10n_es_aeat_verifactu/models/account_move.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Aures TIC - Almudena de La Puente <almudena@aurestic.es>
+# Copyright 2024 Aures Tic - Jose Zambudio <jose@aurestic.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import pytz
@@ -118,7 +119,7 @@ class AccountMove(models.Model):
         return ""
 
     def _get_verifactu_registration_date(self):
-        # Date format must be like "2024-01-01T19:20:30+01:00"
+        # Date format must be ISO 8601
         return pytz.utc.localize(self.create_date).isoformat()
 
     @api.model
@@ -139,22 +140,13 @@ class AccountMove(models.Model):
         previousHash = self._get_verifactu_previous_hash()
         registrationDate = self._get_verifactu_registration_date()
         verifactu_hash_string = (
-            "IDEmisorFactura={}&"
-            "NumSerieFactura={}&"
-            "FechaExpedicionFactura={}&"
-            "TipoFactura={}&"
-            "CuotaTotal={}&"
-            "ImporteTotal={}&"
-            "Huella={}&"
-            "FechaHoraHusoGenRegistro={}"
-        ).format(
-            issuerID,
-            serialNumber,
-            expeditionDate,
-            documentType,
-            amountTax,
-            amountTotal,
-            previousHash,
-            registrationDate,
+            f"IDEmisorFactura={issuerID}&"
+            f"NumSerieFactura={serialNumber}&"
+            f"FechaExpedicionFactura={expeditionDate}&"
+            f"TipoFactura={documentType}&"
+            f"CuotaTotal={amountTax}&"
+            f"ImporteTotal={amountTotal}&"
+            f"Huella={previousHash}&"
+            f"FechaHoraHusoGenRegistro={registrationDate}"
         )
         return verifactu_hash_string

--- a/l10n_es_aeat_verifactu/tests/__init__.py
+++ b/l10n_es_aeat_verifactu/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_10n_es_aeat_verifactu

--- a/l10n_es_aeat_verifactu/tests/test_10n_es_aeat_verifactu.py
+++ b/l10n_es_aeat_verifactu/tests/test_10n_es_aeat_verifactu.py
@@ -22,24 +22,23 @@ class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase
         expected_hash = (
             "3C464DAF61ACB827C65FDA19F352A4E3BDC2C640E9E9FC4CC058073F38F12F60"
         )
+        issuerID = "89890001K"
+        serialNumber = "12345678/G33"
+        expeditionDate = "01-01-2024"
+        documentType = "F1"
+        amountTax = "12.35"
+        amountTotal = "123.45"
+        previousHash = ""
+        registrationDate = "2024-01-01T19:20:30+01:00"
         verifactu_hash_string = (
-            "IDEmisorFactura={}&"
-            "NumSerieFactura={}&"
-            "FechaExpedicionFactura={}&"
-            "TipoFactura={}&"
-            "CuotaTotal={}&"
-            "ImporteTotal={}&"
-            "Huella={}&"
-            "FechaHoraHusoGenRegistro={}"
-        ).format(
-            "89890001K",
-            "12345678/G33",
-            "01-01-2024",
-            "F1",
-            "12.35",
-            "123.45",
-            "",
-            "2024-01-01T19:20:30+01:00",
+            f"IDEmisorFactura={issuerID}&"
+            f"NumSerieFactura={serialNumber}&"
+            f"FechaExpedicionFactura={expeditionDate}&"
+            f"TipoFactura={documentType}&"
+            f"CuotaTotal={amountTax}&"
+            f"ImporteTotal={amountTotal}&"
+            f"Huella={previousHash}&"
+            f"FechaHoraHusoGenRegistro={registrationDate}"
         )
         sha_hash_code = sha256(verifactu_hash_string.encode("utf-8"))
         hash_code = sha_hash_code.hexdigest().upper()

--- a/l10n_es_aeat_verifactu/tests/test_10n_es_aeat_verifactu.py
+++ b/l10n_es_aeat_verifactu/tests/test_10n_es_aeat_verifactu.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Aures TIC - Almudena de La Puente <almudena@aurestic.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from hashlib import sha256
+
+from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_certificate import (
+    TestL10nEsAeatCertificateBase,
+)
+from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_mod_base import (
+    TestL10nEsAeatModBase,
+)
+
+
+class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_verifactu_hash_code(self):
+        # based on AEAT Verifactu documentation
+        # https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Veri-Factu_especificaciones_huella_hash_registros.pdf  # noqa: B950
+        expected_hash = (
+            "3C464DAF61ACB827C65FDA19F352A4E3BDC2C640E9E9FC4CC058073F38F12F60"
+        )
+        verifactu_hash_string = (
+            "IDEmisorFactura={}&"
+            "NumSerieFactura={}&"
+            "FechaExpedicionFactura={}&"
+            "TipoFactura={}&"
+            "CuotaTotal={}&"
+            "ImporteTotal={}&"
+            "Huella={}&"
+            "FechaHoraHusoGenRegistro={}"
+        ).format(
+            "89890001K",
+            "12345678/G33",
+            "01-01-2024",
+            "F1",
+            "12.35",
+            "123.45",
+            "",
+            "2024-01-01T19:20:30+01:00",
+        )
+        sha_hash_code = sha256(verifactu_hash_string.encode("utf-8"))
+        hash_code = sha_hash_code.hexdigest().upper()
+        self.assertEqual(hash_code, expected_hash)

--- a/l10n_es_aeat_verifactu/views/account_move_view.xml
+++ b/l10n_es_aeat_verifactu/views/account_move_view.xml
@@ -18,6 +18,9 @@
                         name="group_aeat_information"
                     >
                         <field name="verifactu_enabled" invisible="1" />
+                        <field name="verifactu_document_type" />
+                        <field name="verifactu_hash_string" />
+                        <field name="verifactu_hash" />
                     </group>
                     <group
                         string="Veri*FACTU Result"


### PR DESCRIPTION
Añadido la lógica que generará el hash de las facturas. Basado en la documentación de la aeat
https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Veri-Factu_especificaciones_huella_hash_registros.pdf
De momento son campos compute y sin store True para poder ir avanzando.

 
- [ ] Pendiente decidir de qué modo se va a saber cuál es la factura anterior enviada, ya que el hash de una factura a su vez está compuesto por el hash de la anterior factura enviada.
 
- [ ] Pendiente decidir en qué momento generaremos el hash y que se guarde en la factura.
 
- [ ] El tipo de documento de verifactu, de momento es un selection, si esos son los tipos definitivos podríamos convertirlo a un modelo y un data