### PR TITLE
[FIX][16.0] Formateo importe a dos decimales en URL QR

### DIFF
--- a/l10n_es_verifactu/models/account_move.py
+++ b/l10n_es_verifactu/models/account_move.py
@@ -538,7 +538,7 @@ class AccountMove(models.Model):
                 ("nif", company_vat),
                 ("numserie", self.name),
                 ("fecha", self.invoice_date.strftime("%d-%m-%Y")),
-                ("importe", amount_total),
+                ("importe", f"{amount_total:.2f}"),
             ]
         )
 


### PR DESCRIPTION
@almumu Para cumplir límite AEAT evitando errores con números flotantes.